### PR TITLE
Set [current-page:url:absolute] as referrer tag value to set correct HTTP referer header

### DIFF
--- a/config/install/metatag.metatag_defaults.global.yml
+++ b/config/install/metatag.metatag_defaults.global.yml
@@ -9,7 +9,7 @@ tags:
   rights: '©[current-date:html_year] [site:name]. All rights reserved.'
   shortlink: '[current-page:url:unaliased]'
   generator: Varbase
-  referrer: origin
+  referrer: '[current-page:url:absolute]'
   google_plus_image: '[site:url][default-active-theme:path]/share-image.png'
   mobileoptimized: width
   apple_mobile_web_app_capable: 'yes'


### PR DESCRIPTION
When referrer head tag is set to origin, it resolves to origin address - up to slash. For example, even on http://www.example.com/some-page, it resolves to http://www.example.com/. This causes incorrect behaviour, if HTTP referrer matters.